### PR TITLE
Refactor Camel Case Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
 .idea/
+coverage.out
 
 # default file
 file.toml

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -57,6 +58,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -82,6 +84,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/tomgos.go
+++ b/tomgos.go
@@ -40,27 +40,24 @@ type generator struct {
 }
 
 // thanks to https://www.socketloop.com/tutorials/golang-underscore-or-snake-case-to-camel-case-example
-func snakeCaseToCamelCase(inputUnderScoreStr string) (camelCase string) {
+// From https://github.com/toml-lang/toml#keys
+// Bare keys may only contain ASCII letters, ASCII digits, underscores, and dashes (A-Za-z0-9_-).
+func keyToCamelCase(input string) (camelCase string) {
 	isToUpper := false
+	camelCase = ""
 
-	for k, v := range inputUnderScoreStr {
-		if k == 0 {
-			camelCase = strings.ToUpper(string(inputUnderScoreStr[0]))
+	for k, v := range input {
+		// TODO: what if first char is a number
+		if v == '_' || v == '-' {
+			isToUpper = true
+		} else if k == 0 || isToUpper {
+			camelCase += strings.ToUpper(string(v))
+			isToUpper = false
 		} else {
-			if isToUpper {
-				camelCase += strings.ToUpper(string(v))
-				isToUpper = false
-			} else {
-				if v == '_' {
-					isToUpper = true
-				} else {
-					camelCase += string(v)
-				}
-			}
+			camelCase += strings.ToLower(string(v))
 		}
 	}
 	return
-
 }
 
 var re = regexp.MustCompile(`\{(.*?)\}`)
@@ -134,7 +131,7 @@ func (g generator) Generate(tomlPathFile string) ([]byte, error) {
 			}
 
 			f := StructFields{
-				Name:           snakeCaseToCamelCase(rawKey),
+				Name:           keyToCamelCase(rawKey),
 				Type:           typeName,
 				JSONDescriptor: strings.ToLower(rawKey),
 			}

--- a/tomgos_test.go
+++ b/tomgos_test.go
@@ -1,0 +1,70 @@
+package tomgos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyToCamelCase(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple key",
+			input:    "key",
+			expected: "Key",
+		},
+		{
+			name:     "simple key with dash (-)",
+			input:    "this-key",
+			expected: "ThisKey",
+		},
+		{
+			name:     "simple key with underscore (_)",
+			input:    "this_key",
+			expected: "ThisKey",
+		},
+		{
+			name:     "simple key with number (0-9)",
+			input:    "this-is-007",
+			expected: "ThisIs007",
+		},
+		{
+			name:     "simple key with uppercase (A-Z)",
+			input:    "wHatEvEr",
+			expected: "Whatever",
+		},
+		{
+			name:     "dash first key",
+			input:    "-key",
+			expected: "Key",
+		},
+		{
+			name:     "underscore first key",
+			input:    "_key",
+			expected: "Key",
+		},
+		{
+			name:     "number first key",
+			input:    "9key",
+			expected: "9key",
+		},
+		{
+			name:     "complex key combination",
+			input:    "-this-is_kINda-r4Nd0m-KEY",
+			expected: "ThisIsKindaR4nd0mKey",
+		},
+	}
+
+	assert := assert.New(t)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := keyToCamelCase(tc.input)
+
+			assert.Equal(tc.expected, output)
+		})
+	}
+}


### PR DESCRIPTION
[Keys](https://github.com/toml-lang/toml#keys) specification in TOML can be more than snake case
This PR only cover bare keys specification `Bare keys may only contain ASCII letters, ASCII digits, underscores, and dashes (A-Za-z0-9_-).`
- [x] Simplify camel case generator
- [x] Handle underscores
- [x] Handle uppercase letter in the middle of string
- ~~Handle number if first letter~~